### PR TITLE
Add the ability to whitelist by path

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ particular vulnerability. For example:
       "https://github.com/angular/angular.js/commit/6476af83cd0418c84e034a955b12a842794385c4",
       "https://github.com/angular/angular.js/issues/11352"
     ],
+    "depPaths": [
+      "/colors/angular",
+      "/react/colors/angular",
+      "/react/brace-expansion/angular"
+    ],
     "published": 0,
     "updated": 1493261505026
   },
@@ -147,7 +152,8 @@ Here is the simplest example:
 
 The document is a JSON object, where the field names are the names of packages which contain
 the vulnerabilities, and the value is a list of the vulnerabilities affecting the package that
-should be filtered. The minimal data required is the ID for the vulnerability.
+should be filtered. The minimal data required is the ID for the vulnerability. Dependency paths
+may be the full path of the dependency or any matching regular expression.
 
 And now something a bit more useful.
 
@@ -160,6 +166,10 @@ And now something a bit more useful.
       "description": "Fixed root path disclosure vulnerability in express.static, res.sendfile, and res.sendFile",
       "versions": [
         "&lt;3.19.1 || >=4.0.0 &lt;4.11.1"
+      ],
+      "dependencyPaths": [
+        "/colors/expressjs",
+        "/react/.*
       ]
     },
     ...
@@ -168,7 +178,7 @@ And now something a bit more useful.
 ...
 ```
 
-Here we reproduced the title, description, and version range of the vulnerability that is being
+Here we reproduced the title, description, dependency paths, and version range of the vulnerability that is being
 filtered. The data was copied straight from the JSON in the generated report. You can include any
 of the fields that you feel are most useful in documenting the vulnerability.
 

--- a/audit-package.js
+++ b/audit-package.js
@@ -93,7 +93,7 @@ auditPackagesImpl = function(depList, callback) {
 		{
 			// Get the current package/version
 			var dep = depList.shift();
-			pkgs.push({pm: dep.pm, name: dep.name, version: dep.version})
+			pkgs.push({pm: dep.pm, name: dep.name, version: dep.version, depPaths: dep.depPaths})
 
 			if(depList.length == 0) break;
 		}
@@ -117,6 +117,7 @@ auditPackageBatchImpl = function(pkgs, onResult, onComplete) {
 		} else {
 			for (var i = 0; i < data.length; i++) {
 				data[i].version = pkgs[i].version;
+				data[i].depPaths = pkgs[i].depPaths;
 				onResult(undefined, data[i]);
 			}
 			onComplete();


### PR DESCRIPTION
In some cases, a package is relied upon by multiple other packages.
In those cases, some of the base packages may be of little concern --
for example, if it's used only for testing. When that happens, we want
to whitelist that specific usage, but not other uses or new usages that
may cause more major concerns

Usage:
 - When the scan runs and a vulnerability is found, it will print out
   the path of each matching node dependency
 - The whitelist file now supports an optional array of
   "dependencyPaths"; they can be the entire path or a regex
 - When scanning and using a whitelist, if a vulnerability is found
   any paths that match a whitelisted dependency path will be ignored