### PR TITLE
Remove ternary that will never evaluate true

### DIFF
--- a/audit.js
+++ b/audit.js
@@ -147,7 +147,6 @@ if (program['quiet']) {
     transports: [
       new (winston.transports.Console)({
         level: process.env.LOG_LEVEL ||
-          (program['quiet']?'error':false) ||
           (program['verbose']?'verbose':false) ||
           (LOGGER_LEVELS.includes(program['level'])?program['level']:false)
           || 'info',


### PR DESCRIPTION
Consider the following code block:
```
//Set logging level based on environmental value or flag
let logger = undefined;
if (program['quiet']) {
  logger = new (winston.Logger)();
} else {
  logger = new (winston.Logger)({
    transports: [
      new (winston.transports.Console)({
        level: process.env.LOG_LEVEL ||
          (program['quiet']?'error':false) ||
          (program['verbose']?'verbose':false) ||
          (LOGGER_LEVELS.includes(program['level'])?program['level']:false)
          || 'info',
        formatter: logFormatter})
    ]
  });
}
```
The `if/else` statement begins by evaluating `program['quiet']`. If that value is `undefined` or `null` or otherwise falsy, code path falls through the `else` statement.

Here, `program['quiet']` is evaluated _again_ for truthiness. In this code path, though, we've already asserted that it's `false`. So that ternary will always return `false`. And as such, that `or` statement expression will never evaluate to `true`. So it can be removed altogether.